### PR TITLE
fix(bpjson): title now in correct position

### DIFF
--- a/src/lib/BPJsonGenerator/styles.js
+++ b/src/lib/BPJsonGenerator/styles.js
@@ -7,7 +7,7 @@ const Styles = (theme) => ({
   },
   wrapper: {
     display: 'flex',
-    flexDirection: 'column',
+    flexDirection: 'column !important',
     marginBottom: theme.spacing(2)
   },
   dropzoneArea: {
@@ -116,7 +116,7 @@ const Styles = (theme) => ({
   nodeWrapper: {
     display: 'flex',
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: 'center'
   },
   locationWrapper: {
     display: 'flex',


### PR DESCRIPTION
### Titles now in correct position

### What does this PR do?

- Resolve https://github.com/eoscostarica/eosio-dashboard/issues/900
### Steps to test

1. See BPjson generator correct layout

![image](https://user-images.githubusercontent.com/55892352/190235140-b8f132db-8f3e-4f69-ad6e-6cbc0d9929d5.png)

#### CheckList

- [ ] Follow proper Markdown format
- [ ] The content is adequate
- [ ] The content is available in both english and spanish
- [ ] I Ran a spell check