### PR TITLE
fix(workflows): fix action inputs

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: storybook-static
+          token: ${{ secrets.ACCESS_TOKEN }}
+          branch: gh-pages
+          folder: storybook-static


### PR DESCRIPTION
- According to the [migration guide](https://github.com/JamesIves/github-pages-deploy-action/discussions/592) ACCESS_TOKEN input is deprecated and now all inputs should now be lower cased using kebab casing. 